### PR TITLE
Fix removing the tmp file

### DIFF
--- a/new-package.sh
+++ b/new-package.sh
@@ -389,7 +389,7 @@ done
 mv "./_tmp/$TASKID" "./$TASKID"
 [ -n "$OLDNAME" ] && echo "$OLDNAME" >"./${TASKID}/.old-name"
 
-rm -f./_tmp/new-package-settings.env
+rm -f ./_tmp/new-package-settings.env
 
 bold "Created new task in ./$TASKID"
 exit 0


### PR DESCRIPTION
The missing space caused `rm` to parse the whole thing as flags, thus it failed to delete the file in `_tmp` and the next invocation of `new-package.sh` had to ask whether to recover the old settings.